### PR TITLE
Fixed link to "Creating a Code Profiler in Haxe using Macros"

### DIFF
--- a/src/roundups/314.md
+++ b/src/roundups/314.md
@@ -65,8 +65,8 @@ This should gain some traction as Haxe increases in popularity, the Checkstyle
 [library][l14] by [Adi Reddy Mora][tw8] which is an _“automated code analysis
 tool ideal for projects that want to enforce coding conventions”_.
 
-For those of you who have wanted a macro tutorial, wait now more! Learn how to
-[Create a Code Profiler in Haxe using Macros][l15] from Kenton Hamaluik, who guides
+For those of you who have wanted a macro tutorial, wait no more! Learn how to
+[Create a Code Profiler in Haxe using Macros][l24] from Kenton Hamaluik, who guides
 you through many macro features along the way. There are a few other tutorials
 out there as well, [Compile Time Macros][l15] by [Sven Bergström][tw4] and
 [Haxe Macros][l16] by [Mark Knol][tw9].
@@ -112,6 +112,7 @@ an elite team of Haxe users who are working on OpenFL's console support.
 [tw2]: https://twitter.com/RealyUniqueName "@RealyUniqueName"
 [tw1]: https://twitter.com/HaxorEngine "@HaxorEngine"
 
+[l24]: http://hamaluik.com/posts/creating-a-code-profiler-in-haxe-using-macros/ "Creating a Code Profiler in Haxe Using Macros"
 [l23]: https://twitter.com/PuzzlTweet "@PuzzlTweet"
 [l22]: https://gist.github.com/tong/5038106 "haxelib-completion.sh"
 [l21]: https://github.com/luboslenco/gamecenter_kha "Game Center Kha on GitHub"


### PR DESCRIPTION
The link was originally using `[l15]` which pointed to Sven's blog post. Added `[l24]` pointing to Kenton's post.