### PR TITLE
fix link for "Add a video related to Haxe"

### DIFF
--- a/src/roundups/471.md
+++ b/src/roundups/471.md
@@ -52,7 +52,7 @@ Welcome to the latest edition of the Haxe Roundup. [Haxe](http://haxe.org/?ref=h
 - [Videos from HaxeUp Saint-Petersburg](https://www.youtube.com/playlist?list=PLU2M-shPcj1y4bsi1O2hhOjR28CScrMcQ) _(in Russian)_. :ru:
 - [Heaps Game Engine -- The Awesome Haxe Engine powering Dead Cells](https://www.youtube.com/watch?v=do97fnKRV8A) - a new video from [Gamefromscratch](https://www.gamefromscratch.com/post/2019/03/11/Heaps-160-Released.aspx).
 - There was HTML5 meetup at the office of Mail.ru Group in Moscow, Russia on 13th of March. One of the talks was about using Haxe - _"Studio NX team's experience of porting Chaos Chronicles game from Flash to HTML5. What we did right and what we did wrong"_ by Dmitry Skvortsov from Studio NX. Here is the [recording](https://youtu.be/VD4uAR2E394?t=7595) _(in Russian)_. :ru:
-- _Add a [video](https://github.com/skial/haxe.io/labels/jobs) related to Haxe_.
+- _Add a [video](https://github.com/skial/haxe.io/labels/video) related to Haxe_.
 
 ### Upcoming Events & Talks
 


### PR DESCRIPTION
currently it leads to jobs related issues: https://github.com/skial/haxe.io/labels/jobs