### PR TITLE
Move giffon.io to Open Source

### DIFF
--- a/src/roundups/492.md
+++ b/src/roundups/492.md
@@ -87,12 +87,12 @@ Welcome to the latest edition of the Haxe Roundup. [Haxe](http://haxe.org/?ref=h
 #### Open Source
 
 - Rouge [pull request](https://github.com/rouge-ruby/rouge/pull/815) has been merged and will be released as `3.9.0` on August 20th, meaning Haxe syntax highlighting on GitLab will become possible! :star2:
+- [Giffon.io](https://giffon.io/) is [Haxe 4 ready now!](https://twitter.com/andy_li/status/1160148426111111168)
 - Post-Processing Module `v0.3` for Armory3D by [Alexander Kleemann](https://twitter.com/NaxelaAlexander/status/1161302424117813248). Checkout the [video](https://www.youtube.com/watch?v=ctAQag4xknY&feature=youtu.be) and [web-demo](http://laboratory.naxela.info/experiment_3/).
 - 'Damilare Darmie Akinlaja is building a [virtual machine](https://github.com/darmie/cabasa) for [WebAssembly in Haxe](https://twitter.com/Damilare_/status/1160084426396708864). The long term goal of this project is to be able to load full Haxe code at runtime from any Haxe target. :+1:
 
 #### Closed Source
 
-- [Giffon.io](https://giffon.io/) is [Haxe 4 ready now!](https://twitter.com/andy_li/status/1160148426111111168)
 - [Birds!](https://twitter.com/kircode/status/1159530042369744897) in Phantom Path by Kirill Poletaev.
 - [Interactive credits](https://twitter.com/Geokureli/status/1160637348171976707) by Geokureli.
 - [New GIF](https://twitter.com/1speed2gamedev/status/1160066947016462336) from WIP 2D adventure game by [1speed studio](https://twitter.com/1speed2gamedev) showing new assets and combat.


### PR DESCRIPTION
giffon.io is an open source project. you can check out it at https://github.com/giffon/giffon