### PR TITLE
HashLink 1.11, not 1.1

### DIFF
--- a/src/roundups/523.md
+++ b/src/roundups/523.md
@@ -13,7 +13,7 @@ Welcome to the latest edition of the Haxe Roundup. [Haxe](http://haxe.org/?ref=h
 
 ### News and Articles
 
-- HashLink `1.1` has been [released](https://twitter.com/ncannasse/status/1244605603894394880)! This release includes a native CPU profiler and much more! :tada:
+- HashLink `1.11` has been [released](https://github.com/HaxeFoundation/hashlink/releases/tag/1.11)! This release includes a native CPU profiler and much more! :tada:
 - Armory Digest [April 2020](https://github.com/Naxela/Armory_Digest/blob/master/April-2020/AD-april-2020.md). :star:
 - A year late, but the [fifth devlog](https://antriel.com/post/rpg-devlog-5/) by [Antriel](https://twitter.com/PeterAchberger/status/1244718088102326274) is out. :+1:
 - [Lubos Lenco](https://twitter.com/luboslenco) has released [Iron `2020.4`](https://github.com/armory3d/iron/releases/tag/20.04) and [Armory `2020.4`](https://github.com/armory3d/armory/releases/tag/20.04).


### PR DESCRIPTION
HashLink 1.1 is ancient. ;) Also, it seems better to link to the release notes instead, as the tweet doesn't contain much useful information.